### PR TITLE
Add initial version of the research highlights page

### DIFF
--- a/highlights.html
+++ b/highlights.html
@@ -1,0 +1,54 @@
+<!--#include virtual="/sigsoftheader.html" -->
+
+  <div id="breadcrumb">
+   <a href="index.html">Home</a> -&gt; Research Highlights
+  </div>
+
+  <div id="mat2" class="clear">
+   <div id="mat3">
+    <div id="mat4">
+     <div id="colfull">
+
+      <div class="item">
+       <h1>Research Highlights</h1>
+       Starting in 2020, SIGSOFT is selecting papers from its sponsored conferences that show recent, significant, and exciting results that are also of general interest to the computer science research community. These papers, called <strong>SIGSOFT Research Highlights</strong>, are also recommended for consideration for the <a href="https://cacm.acm.org/about-communications/author-center/author-guidelines/about-research-highlights/">Research Highlights section</a> of the <a href="https://cacm.acm.org">Communications of the ACM</a>.
+
+       <h2>Nomination Process</h2>
+
+       <p>The committee considers nominated papers from two sources:</p>
+
+       <ul>
+         <li><strong>Conference Organizers:</strong> The chair of the SIGSOFT Research Highlights Committee will solicit nominations from the program chairs of SIGSOFT-sponsored conferences.</li>
+         <li><strong>Community:</strong> Any SIGSOFT member may nominate a paper appearing in a SIGSOFT conference, provided they do not have a <a href="https://www.acm.org/publications/policies/conflict-of-interest">conflict of interest</a>.
+      </ul>
+
+      <p>To nominate a paper, send an email from your <i>institutional email address</i> to <a href="mailto:highlights_sigsoft@acm.org">highlights_sigsoft@acm.org</a> with the following information:</p>
+
+      <ol>
+        <li>Your name, affiliation, and ACM member number;</li>
+        <li>A link to the official publisher's page for the paper or, if the paper is not yet available in a digital library, its full bibliographic entry and a pdf of the paper;</li>
+        <li>The statement "I confirm that I am not in conflict of interest with this paper";</li>
+        <li>A nomination statement of 150 to 200 words that indicates, as specifically as possible, why the paper reports on <i>significant and exciting</i> results that are also of <i>general interest</i> to the computer science research community.
+      </ol>
+
+      <i>By submitting a nomination statement, nominators authorize the SIGSOFT Research Highlights Committee to reuse all or a portion of the statement for the purpose of nominating the paper further as a CACM Research Highlight, if applicable.</i>
+
+      <h2>SIGSOFT Research Highlights Committee</h2>
+
+      <ul>
+        <li><a href="https://www.cs.mcgill.ca/~martin/">Martin Robillard</a>, McGill University (Chair)</li>
+        <li><a href="http://collab.di.uniba.it/nicole/">Nicole Novielli</a>, University of Bari</li>
+        <li><a href="https://software-lab.org/people/Michael_Pradel.html">Michael Pradel</a>, University of Stuttgart</li>
+        <li><a href="https://researcher.watson.ibm.com/researcher/view.php?person=us-sinhas">Saurabh Sinha</a>, IBM Research</li>
+        <li><a href="https://lafhis.dc.uba.ar/~suchitel">Sebastian Uchitel</a>, University of Buenos Aires</li>
+        <li><a href="https://www.microsoft.com/en-us/research/people/dongmeiz/">Dongmei Zhang</a>, Microsoft Research</li>
+      </ul>
+
+      </div>
+     </div>
+    </div>
+
+   </div>
+  </div>
+
+<!--#include virtual="/sigsoftfooter.html" -->


### PR DESCRIPTION
The initial version of the Research Highlights page is self-contained and follows the model of the other contents pages. However, it is not linked to the rest of the site.