### PR TITLE
redirect awards landing page to new awards landing page

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,6 +2,7 @@ AddType text/html .html
 AddHandler server-parsed .html 
 Options FollowSymLinks Includes
 
+RedirectMatch 301 /awards.html https://www2.sigsoft.org/awards/sigsoftawards/
 RedirectMatch 301 /awards/distinguishedServiceAward.html https://www2.sigsoft.org/awards/distinguishedservice/
 RedirectMatch 301 /awards/outstandingResearchAward.html https://www2.sigsoft.org/awards/outstandingresearch/
 RedirectMatch 301 /awards/influentialEducatorAward.html https://www2.sigsoft.org/awards/influentialeducator/


### PR DESCRIPTION
Make the top-level  awards page redirect to https://www2.sigsoft.org/awards/sigsoftawards/ to address the fact that a google search surfaces the old site, first:

<img width="1031" height="479" alt="Screenshot 2026-05-05 at 11 24 01 AM" src="https://github.com/user-attachments/assets/0fee81b9-ef63-4f4b-ad87-fe5ece05e821" />
